### PR TITLE
Making All-In-One universal (both JP and US regions)

### DIFF
--- a/mod.yml
+++ b/mod.yml
@@ -1,7 +1,7 @@
 title: All-in-One
 originalAuthor: Various sources credited in the Readme
 game: kh2
-description: A compilation of mod to be used with the Garden of Assemblage mod and Randomizer for general purposes. It is now compatible for both US and JP regions.
+description: A compilation of mod to be used with the Garden of Assemblage mod and Randomizer for general purposes. It is now compatible with both US and JP regions.
 assets:
 #Detection Saber Model
 - name: obj/W_EX010_Y0.a.fm

--- a/mod.yml
+++ b/mod.yml
@@ -214,6 +214,7 @@ assets:
 - name: msg/us/sys.bar
   method: binarc
   multi:
+  - name: msg/jp/sys.bar
   - name: msg/uk/sys.bar
   source:
   - name: sys
@@ -225,6 +226,7 @@ assets:
 - name: msg/us/hb.bar
   method: binarc
   multi:
+  - name: msg/jp/hb.bar
   - name: msg/uk/hb.bar
   source:
   - name: hb
@@ -236,6 +238,7 @@ assets:
 - name: msg/us/tr.bar
   method: binarc
   multi:
+  - name: msg/jp/tr.bar
   - name: msg/uk/tr.bar
   source:
   - name: tr

--- a/mod.yml
+++ b/mod.yml
@@ -1,7 +1,7 @@
 title: All-in-One
 originalAuthor: Various sources credited in the Readme
 game: kh2
-description: A compilation of mod to be used with the Garden of Assemblage mod and Randomizer for general purposes.
+description: A compilation of mod to be used with the Garden of Assemblage mod and Randomizer for general purposes. It is now compatible for both US and JP regions.
 assets:
 #Detection Saber Model
 - name: obj/W_EX010_Y0.a.fm

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
-# All-in-One
+# All-in-One (for both US and JP regions)
 
 Changes:
-- Remembrance & Tranquil synth icons fix
+- Remembrance & Tranquil synth icons fix (only for US region)
 - Model for Detection Saber and Frontier of Ultima
 - New "vanilla" stats as follows:
   - 3,1 Defender for FAKE


### PR DESCRIPTION
This change makes All-In-One compatible with both languagepack-en and languagepack-enjp.
Also, if installed in conjunction with my languagepack-en (universal as well), people only have to set region in OpenKH and that's it.